### PR TITLE
[WIP] Simplify flavor handling.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,7 +31,7 @@ node.default['qa-chef-server-cluster']['chef-server'].tap do |chef_server|
   # TODO Consider...
   # chef_server['artifactory']['integration_builds'] = false
   # chef_server['artifactory']['repo'] = 'omnibus-stable-local'
-  chef_server['flavor'] = 'chef_server' # 'enterprise_chef'
+  chef_server['flavor'] = 'chef_server'
   chef_server['api_fqdn'] = 'api.chef.sh'
   chef_server['install_method'] = 'artifactory' # 'packagecloud', 'chef-server-ctl'
   chef_server['url'] = nil # setting this to a direct download url path will override all install_methods

--- a/libraries/qa_chef_server_cluster_dsl.rb
+++ b/libraries/qa_chef_server_cluster_dsl.rb
@@ -24,7 +24,7 @@ module QaChefServerCluster::DSL
   include ChefIngredientCookbook::Helpers
   include QaChefServerCluster::ServerFlavorHelper
 
-  SUPPORTED_FLAVORS = %w( chef_server enterprise_chef )
+  SUPPORTED_FLAVORS = %w( chef_server enterprise_chef open_source_chef )
 
   def current_flavor
     flavor = node['qa-chef-server-cluster']['chef-server']['flavor']
@@ -34,36 +34,23 @@ module QaChefServerCluster::DSL
     flavor
   end
 
-  def set_to_a_latest_version?(attribute)
-    [ :latest, :latest_stable, :latest_current,
-      'latest', 'latest_stable', 'latest_current',
-      'latest-stable', 'latest-current'
-    ].include?(attribute) ? true : false
-  end
-
   #
   # Returns a ChefServer instance for the current_flavor
   #
   def current_server
     case current_flavor
     when 'chef_server'
-      # TODO this is a such an ugly hack... must fix
-      version = node['qa-chef-server-cluster']['chef-server']['version']
-      version = '0' if version.nil?
-      if set_to_a_latest_version?(version) || version.start_with?('12')
-        current_server = chef_server
-      else
-        current_server = open_source_chef
-      end
+      chef_server
+    when 'open_source_chef'
+      open_source_chef
     when 'enterprise_chef'
-      current_server = enterprise_chef
+      enterprise_chef
     else
       raise "Chef Server flavor '#{current_flavor}' not supported.  Must be one of: #{SUPPORTED_FLAVORS}"
     end
-    current_server
   end
 
-  def create_chef_server_directory  
+  def create_chef_server_directory
     directory current_server.config_path do
       mode 0755
       recursive true

--- a/spec/unit/recipes/generate_test_data_recipe_spec.rb
+++ b/spec/unit/recipes/generate_test_data_recipe_spec.rb
@@ -5,7 +5,6 @@ describe 'qa-chef-server-cluster::generate-test-data' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'chef_server'
-        node.set['qa-chef-server-cluster']['chef-server']['version'] = :latest
       end.converge(described_recipe)
     end
 
@@ -31,8 +30,7 @@ describe 'qa-chef-server-cluster::generate-test-data' do
   context 'when open source chef' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'chef_server'
-        node.set['qa-chef-server-cluster']['chef-server']['version'] = '11.0.0'
+        node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'open_source_chef'
       end.converge(described_recipe)
     end
 
@@ -78,6 +76,18 @@ describe 'qa-chef-server-cluster::generate-test-data' do
 
     it 'runs setup script' do
       expect(chef_run).to run_execute('sudo ./setup-ec.sh') 
+    end
+  end
+
+  context 'when bad server' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'bad_server'
+      end.converge(described_recipe)
+    end
+
+    it 'raises an exception' do
+      expect { chef_run }.to raise_error(RuntimeError, /bad_server/)
     end
   end
 end

--- a/spec/unit/recipes/standalone_recipe_chef_server_spec.rb
+++ b/spec/unit/recipes/standalone_recipe_chef_server_spec.rb
@@ -6,7 +6,6 @@ describe 'qa-chef-server-cluster::standalone' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
           node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'chef_server'
-          node.set['qa-chef-server-cluster']['chef-server']['version'] = :latest
         end.converge(described_recipe)
       end
 
@@ -18,8 +17,7 @@ describe 'qa-chef-server-cluster::standalone' do
     context 'when 11.x version' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'chef_server'
-          node.set['qa-chef-server-cluster']['chef-server']['version'] = '11.0.0'
+          node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'open_source_chef'
         end.converge(described_recipe)
       end
 


### PR DESCRIPTION
This will need the `chef_server flavor` attr to support cs, ec, and osc.  It should be that way now, but will need  some cleanup with some the convoluted version checking logic.

The chef-server-acceptance build cookbook will also need to be updated