### PR TITLE
WIP: mvp standalone changes

### DIFF
--- a/.delivery/build/Berksfile
+++ b/.delivery/build/Berksfile
@@ -6,6 +6,6 @@ cookbook 'delivery-truck',         git: 'https://github.com/opscode-cookbooks/de
 cookbook 'delivery-sugar',         git: 'https://github.com/chef-cookbooks/delivery-sugar.git'
 
 group :delivery do
-  cookbook 'delivery-red-pill', git: 'https://github.com/opscode-cookbooks/delivery-cluster.git', rel: '.delivery/build/cookbooks/delivery-red-pill'
+  cookbook 'delivery-matrix', git: 'https://github.com/opscode-cookbooks/delivery-cluster.git', rel: '.delivery/build/cookbooks/delivery-matrix'
   cookbook 'delivery-sugar-extras', git: 'https://github.com/opscode-cookbooks/delivery-sugar-extras.git'
 end

--- a/.delivery/build/attributes/default.rb
+++ b/.delivery/build/attributes/default.rb
@@ -35,13 +35,11 @@ if node['delivery']['change']['stage'] == 'acceptance'
   ]
 end
 
-default['chef_server_latest_released_version'] = '12.1.2'
-default['chef_server_latest_released_repo'] = 'omnibus-stable-local'
-default['chef_server_latest_released_integration_builds'] = false
+default['chef_server_latest_released_version'] = 'latest'
+default['chef_server_latest_released_channel'] = 'stable'
 
-default['chef_server_test_version'] = '12.2.0'
-default['chef_server_test_repo'] = 'omnibus-current-local'
-default['chef_server_test_integration_builds'] = true
+default['chef_server_test_version'] = 'latest'
+default['chef_server_test_channel'] = 'current'
 
 # Set this attribute to a direct download link (jenkins url) to supercede the chef_server_test-* artifactory attributes
 # default['chef_server_test_url_override'] = 'http://wilson.ci.chef.co/view/Chef%20Server%2012/job/chef-server-12-build/lastSuccessfulBuild/architecture=x86_64,platform=ubuntu-10.04,project=chef-server,role=builder/artifact/omnibus/pkg/chef-server-core_12.2.0+20150901045019-1_amd64.deb'

--- a/.delivery/build/attributes/default.rb
+++ b/.delivery/build/attributes/default.rb
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2015 The Authors, All Rights Reserved.
 
-include_attribute 'delivery-red-pill'
+include_attribute 'delivery-matrix'
 
 default['chef-server-acceptance'] = {}
 default['chef-server-acceptance']['identifier'] = 'standalone-clean'
@@ -12,9 +12,9 @@ default['chef-server-acceptance']['upgrade'] = false
 default['chef-server-acceptance']['delivery-path'] ='/opt/chefdk/embedded/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games'
 
 # By including this recipe we trigger a matrix of acceptance envs specified
-# in the node attribute node['delivery-red-pill']['acceptance']['matrix']
+# in the node attribute node['delivery-matrix']['acceptance']['matrix']
 if node['delivery']['change']['stage'] == 'acceptance'
-  default['delivery-red-pill']['acceptance']['matrix'] = [
+  default['delivery-matrix']['acceptance']['matrix'] = [
     # fresh install of chef_server_version
     'standalone_clean_aws',
     # 'tier_clean_aws',

--- a/.delivery/build/libraries/helpers.rb
+++ b/.delivery/build/libraries/helpers.rb
@@ -9,7 +9,7 @@ module ChefServerAcceptanceCookbook
           repo_config_file = File.join(repo, '.chef', 'config.rb')
 
           command = []
-          command << 'bundle exec'
+          # command << 'bundle exec' TODO: just use chefdk!
           command << 'chef-client -z'
           command << '-p 10257'
           command << "-j #{options[:attributes_file]}" if options[:attributes_file]

--- a/.delivery/build/metadata.rb
+++ b/.delivery/build/metadata.rb
@@ -7,5 +7,6 @@ long_description 'Installs/Configures build'
 version '0.1.1'
 
 depends 'delivery-truck'
-depends 'delivery-red-pill'
+# depends 'delivery-matrix'
+depends 'delivery-matrix'
 depends 'delivery-sugar-extras'

--- a/.delivery/build/recipes/default.rb
+++ b/.delivery/build/recipes/default.rb
@@ -17,5 +17,5 @@ directory gem_cache do
 end
 
 include_recipe 'delivery-sugar-extras::default'
-include_recipe 'delivery-red-pill::default'
+include_recipe 'delivery-matrix::default'
 include_recipe 'delivery-truck::default'

--- a/.delivery/build/recipes/functional.rb
+++ b/.delivery/build/recipes/functional.rb
@@ -6,10 +6,10 @@
 
 # if we are not in the URD run pedant
 if node['delivery']['change']['stage'] == 'acceptance'
-  # This is necessary for delivery-red-pill to catch failures in earlier steps.
+  # This is necessary for delivery-matrix to catch failures in earlier steps.
   # Without including this recipe, the parent job will report success even if the
   # child job failed.
-  include_recipe 'delivery-red-pill::functional'
+  include_recipe 'delivery-matrix::functional'
 
 # this is the only part of the URD we are using currently, publish to github
 elsif node['delivery']['change']['stage'] == 'delivered'

--- a/.delivery/build/recipes/prepare_deps.rb
+++ b/.delivery/build/recipes/prepare_deps.rb
@@ -10,16 +10,17 @@ repo = node['delivery']['workspace']['repo']
 install_dir = '/opt/chefdk'
 gem_cache = File.join(node['delivery']['workspace']['root'], "../../../project_gem_cache")
 
-execute "bundle install --path=#{gem_cache}" do
-  cwd repo
-  environment(
-    'PATH' => node['chef-server-acceptance']['delivery-path'],
-    "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-    "CFLAGS" => "-I#{install_dir}/embedded/include"
-  )
-end
+# execute "bundle install --path=#{gem_cache}" do
+#   cwd repo
+#   environment(
+#     'PATH' => node['chef-server-acceptance']['delivery-path'],
+#     "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+#     "CFLAGS" => "-I#{install_dir}/embedded/include"
+#   )
+# end
 
-execute 'bundle exec berks vendor' do
+# execute 'bundle exec berks vendor' do
+execute 'berks vendor' do
   cwd repo
 end
 

--- a/.delivery/build/recipes/provision.rb
+++ b/.delivery/build/recipes/provision.rb
@@ -31,6 +31,6 @@ ruby_block 'Cleanup AWS instances' do
   end
 end
 
-# Unless delivery-red-pill::functional is also included, the parent job will
+# Unless delivery-matrix::functional is also included, the parent job will
 # report success even if the child job failed.
-include_recipe 'delivery-red-pill::provision'
+include_recipe 'delivery-matrix::provision'

--- a/.delivery/build/recipes/provision_general_prep.rb
+++ b/.delivery/build/recipes/provision_general_prep.rb
@@ -19,7 +19,6 @@ template File.join(node['delivery']['workspace']['repo'], json_filename) do
   variables tags: { delivery_stage: node['delivery']['change']['stage'] },
             url: node['chef_server_test_url_override'],
             chef_version: node['chef_server_test_version'],
-            repo: node['chef_server_test_repo'],
-            integration_builds: node['chef_server_test_integration_builds'],
+            channel: node['chef_server_test_channel'],
             image_id: node['ami']['ubuntu-12.04']
 end

--- a/.delivery/build/recipes/provision_standalone_upgrade_aws.rb
+++ b/.delivery/build/recipes/provision_standalone_upgrade_aws.rb
@@ -15,8 +15,7 @@ template attributes_install_file do
   action :create
   variables tags: { delivery_stage: node['delivery']['change']['stage'] },
             chef_version: node['chef_server_latest_released_version'],
-            repo: node['chef_server_latest_released_repo'],
-            integration_builds: node['chef_server_latest_released_integration_builds'],
+            channel: node['chef_server_latest_released_channel'],
             image_id: node['ami']['ubuntu-12.04']
 end
 

--- a/.delivery/build/recipes/smoke.rb
+++ b/.delivery/build/recipes/smoke.rb
@@ -7,4 +7,4 @@
 # we are ignoring the URD for now
 return unless node['delivery']['change']['stage'] == 'acceptance'
 
-include_recipe 'delivery-red-pill::smoke'
+include_recipe 'delivery-matrix::smoke'

--- a/.delivery/build/templates/default/attributes.json.erb
+++ b/.delivery/build/templates/default/attributes.json.erb
@@ -8,8 +8,7 @@
       "url": "<%= @url %>"
       <% else %>
       "version": "<%= @chef_version %>",
-      "integration_builds": <%= @integration_builds %>,
-      "repo": "<%= @repo %>"
+      "channel": "<%= @channel %>"
       <% end %>
     },
     "aws": {

--- a/.delivery/config.json
+++ b/.delivery/config.json
@@ -13,6 +13,7 @@
     }
   },
   "skip_phases": [
+    "lint",
     "functional",
     "quality",
     "security",

--- a/Berksfile
+++ b/Berksfile
@@ -6,8 +6,6 @@ cookbook 'chef-vault'
 cookbook 'apt'
 cookbook 'chef-ingredient'
 cookbook 'lvm'
-cookbook 'omnibus-artifactory-artifact', git: 'git@github.com:opscode-cookbooks/omnibus-artifactory-artifact.git', branch: 'master'
-cookbook 'packagecloud'
 
 def fixture(name)
   cookbook "#{name}", path: "test/fixtures/cookbooks/#{name}"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -5,36 +5,26 @@ DEPENDENCIES
   chef_package_resource
     path: test/fixtures/cookbooks/chef_package_resource
   lvm
-  omnibus-artifactory-artifact
-    git: git@github.com:opscode-cookbooks/omnibus-artifactory-artifact.git
-    revision: 5056cc3fb3254b9a1d044f7eefe67cbfc4ed5a7a
-    branch: master
-  packagecloud
   qa-chef-server-cluster
     path: .
     metadata: true
 
 GRAPH
-  apt (2.9.2)
-  apt-chef (0.2.0)
-    apt (>= 0.0.0)
-  build-essential (2.2.4)
-  chef-ingredient (0.13.1)
-    apt-chef (>= 0.2.0)
-    yum-chef (>= 0.2.0)
-  chef-vault (1.3.2)
+  apt (3.0.0)
+  build-essential (3.2.0)
+    seven_zip (>= 0.0.0)
+  chef-ingredient (0.18.4)
+  chef-vault (1.3.3)
+  chef_handler (1.3.0)
   chef_package_resource (0.0.0)
     qa-chef-server-cluster (>= 0.0.0)
-  lvm (1.4.0)
-  omnibus-artifactory-artifact (0.3.1)
-  packagecloud (0.1.0)
-  qa-chef-server-cluster (0.1.9)
+  lvm (2.0.0)
+  qa-chef-server-cluster (0.1.10)
     apt (>= 0.0.0)
     build-essential (>= 0.0.0)
     chef-ingredient (>= 0.0.0)
     lvm (>= 0.0.0)
-    omnibus-artifactory-artifact (>= 0.0.0)
-    packagecloud (>= 0.0.0)
-  yum (3.8.2)
-  yum-chef (0.2.1)
-    yum (>= 3.2)
+  seven_zip (2.0.0)
+    windows (>= 1.2.2)
+  windows (1.40.0)
+    chef_handler (>= 0.0.0)

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The machine resources and other cluster-associated provisioning resources (ebs v
 Creating envionment files manually is a chore.  `qa-chef-server-cluster` has a counterpart utility named `qa-csc-config`. You can learn all about `qa-csc-config` by seeing the [README](https://github.com/chef/qa-csc-config)
 
 # License and Author
-Author: Patrick Wright patrick@chef.io.com
+Author: Patrick Wright patrick@chef.io
 
 Copyright (C) 2014-2015 Chef Software, Inc. legal@chef.io
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,11 +10,14 @@ end
 
 node.default['qa-chef-server-cluster']['aws']['machine_options'].tap do |machine_options|
   machine_options['aws_tags'] = { 'X-Project' => 'qa-chef-server-cluster' }
-  machine_options['use_private_ip_for_ssh'] = true
+  # machine_options['transport_address_location'] = :private_ip TODO: use as default
+  machine_options['transport_address_location'] = :public_ip
   machine_options['ssh_username'] = 'ubuntu'
   machine_options['bootstrap_options'].tap do |bootstrap_options|
+    bootstrap_options['associate_public_ip_address'] = true # TODO: remove
     bootstrap_options['key_name'] = 'qa-chef-server-cluster-default'
-    bootstrap_options['subnet_id'] = 'subnet-6fab6818' # QA Private
+    # bootstrap_options['subnet_id'] = 'subnet-6fab6818' # QA Private TODO: use as default
+    bootstrap_options['subnet_id'] = 'subnet-5cab682b' # QA Public
     bootstrap_options['security_group_ids'] = ['sg-52a8f837'] # qa-chef-server-cluster
     bootstrap_options['image_id'] = 'ami-3d50120d' # Ubuntu 14.04
     bootstrap_options['instance_type'] = 'm3.medium'
@@ -25,28 +28,22 @@ node.default['qa-chef-server-cluster']['provisioning-id'] = 'default'
 node.default['qa-chef-server-cluster']['topology'] = nil
 
 node.default['qa-chef-server-cluster']['chef-server'].tap do |chef_server|
-  chef_server['version'] = :latest
-  chef_server['integration_builds'] = false
-  chef_server['repo'] = 'omnibus-stable-local'
+  chef_server['version'] = 'latest'
+  chef_server['channel'] = 'stable'
   chef_server['flavor'] = 'chef_server'
   chef_server['api_fqdn'] = 'api.chef.sh'
-  chef_server['install_method'] = 'artifactory' # 'packagecloud', 'chef-server-ctl'
   chef_server['url'] = nil # setting this to a direct download url path will override all install_methods
 end
 
 node.default['qa-chef-server-cluster']['opscode-manage'].tap do |opscode_manage|
   opscode_manage['version'] = nil
-  opscode_manage['integration_builds'] = false
-  opscode_manage['repo'] = 'omnibus-stable-local'
-  opscode_manage['install_method'] = 'packagecloud' # 'packagecloud', 'chef-server-ctl' 'artifactory'
+  opscode_manage['channel'] = 'stable'
   opscode_manage['url'] = nil # setting this to a direct download url path will override all install_methods
 end
 
 node.default['qa-chef-server-cluster']['chef-ha'].tap do |chef_ha|
-  chef_ha['version'] =  '1.0.0' # TODO: this is annoying to have to set, figure this out
-  chef_ha['integration_builds'] = false
-  chef_ha['repo'] = 'omnibus-stable-local'
-  chef_ha['install_method'] = 'packagecloud' # 'packagecloud', 'chef-server-ctl' 'artifactory'
+  chef_ha['version'] =  '1.0.0'
+  chef_ha['channel'] = 'stable'
   chef_ha['url'] = nil # setting this to a direct download url path will override all install_methods
 end
 

--- a/libraries/chef_package_helper.rb
+++ b/libraries/chef_package_helper.rb
@@ -6,88 +6,37 @@ module QaChefServerCluster
     include QaChefServerCluster::ServerFlavorHelper
 
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize
-    # TODO: Fix this nasty method
     def install_product(resource)
       if resource.package_url
         install_via_url(resource)
-        reconfigure_product(resource) if resource.reconfigure
       elsif resource.version.nil?
         Chef::Log.info "#{resource.product_name} version not set. Not installing package."
       else
-        case resource.install_method
-        when 'artifactory'
-          install_via_artifactory(resource)
-        when 'packagecloud'
-          install_via_packagecloud(resource)
-        when 'chef-server-ctl'
-          # TODO: Should we even handle a server name exception?  Perhaps a whitelist would be better.
-          install_command = "chef-server-ctl install #{chef_ingredient_product_lookup}"
-          # install_command << " --path "if resource.package_source
-          execute install_command
-        else
-          raise 'Must provide a URL or install method.'
-        end
-        reconfigure_product(resource) if resource.reconfigure
+        install_via_channel(resource)
       end
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize
 
     def reconfigure_product(resource)
-      install_mixlib_versioning
+      ensure_mixlib_versioning_gem_installed!
       chef_ingredient resource.product_name do
         action :reconfigure
       end
     end
 
     def chef_ingredient_product_lookup
-      install_mixlib_versioning
+      ensure_mixlib_versioning_gem_installed!
       ingredient_package_name
     end
 
-    # rubocop:disable Metrics/AbcSize
-    def install_via_artifactory(resource)
-      # TODO: what's the deal with chef-manage?????
-      if resource.product_name == 'chef-manage'
-        resource.product_name('opscode-manage')
-        # chef-server-core and chef-server are both in the chef-server repo
-      elsif resource.product_name == 'chef-server'
-        resource.product_name
-      else
-        resource.product_name(chef_ingredient_product_lookup)
-      end
-
-      omnibus_artifactory_artifact resource.product_name do
-        version resource.version
-        integration_builds resource.integration_builds
-        repo resource.repository
-      end
-
+    def install_via_channel(resource)
       chef_ingredient resource.product_name do
-        package_source omnibus_artifactory_artifact_local_path(resource.product_name)
-        config resource.config
-      end
-
-      ingredient_config resource.product_name do
-        only_if { resource.config }
-      end
-    end
-    # rubocop:enable Metrics/AbcSize
-
-    def install_via_packagecloud(resource)
-      ['stable', 'current'].each do |repo|
-        packagecloud_repo "chef/#{repo}" do
-          type value_for_platform_family(:rhel => 'rpm', :debian => 'deb')
-        end
-      end
-
-      chef_ingredient resource.product_name do
+        channel resource.channel.to_sym
         version resource.version
         config resource.config
       end
 
-      ingredient_config resource.product_name do
-        only_if { resource.config }
-      end
+      reconfigure_product(resource) if resource.reconfigure
     end
 
     # rubocop:disable Metrics/AbcSize
@@ -106,6 +55,8 @@ module QaChefServerCluster
       ingredient_config resource.product_name do
         only_if { resource.config }
       end
+
+      reconfigure_product(resource) if resource.reconfigure
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/libraries/chef_package_helper.rb
+++ b/libraries/chef_package_helper.rb
@@ -36,6 +36,10 @@ module QaChefServerCluster
         config resource.config
       end
 
+      ingredient_config resource.product_name do
+        only_if { resource.config }
+      end
+
       reconfigure_product(resource) if resource.reconfigure
     end
 

--- a/libraries/chef_package_resource.rb
+++ b/libraries/chef_package_resource.rb
@@ -32,20 +32,14 @@ class Chef
       # chef_ingredient config
       attribute :config, kind_of: String, default: nil
 
-      # installation method
-      attribute :install_method, kind_of: String, default: nil, equal_to: %w( artifactory packagecloud chef-server-ctl )
-
       # Attribute to install package from remote file
       attribute :package_url, kind_of: String, default: nil
 
       # Shared version for install methods
       attribute :version, kind_of: [String, Symbol], default: nil
 
-      # Artifactory specific
-      attribute :integration_builds, kind_of: [TrueClass, FalseClass, NilClass], default: nil
-
-      # Artifactory specific
-      attribute :repository, kind_of: String, default: nil
+      # Artifact channel
+      attribute :channel, kind_of: [String, Symbol], default: :stable
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer       'Patrick Wright'
 maintainer_email 'patrick@chef.io'
 license          'all_rights'
 description      'Installs/Configures QA clusters'
-version          '0.1.10'
+version          '0.1.11'
 # rubocop:enable Style/SingleSpaceBeforeFirstArg
 
 depends 'chef-ingredient'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,8 +8,6 @@ version          '0.1.10'
 # rubocop:enable Style/SingleSpaceBeforeFirstArg
 
 depends 'chef-ingredient'
-depends 'omnibus-artifactory-artifact'
 depends 'lvm'
 depends 'apt'
 depends 'build-essential'
-depends 'packagecloud'

--- a/recipes/standalone-upgrade.rb
+++ b/recipes/standalone-upgrade.rb
@@ -23,19 +23,15 @@ include_recipe 'qa-chef-server-cluster::node-setup'
 chef_package current_server.package_name do
   action :upgrade
   package_url node['qa-chef-server-cluster']['chef-server']['url']
-  install_method node['qa-chef-server-cluster']['chef-server']['install_method']
   version node['qa-chef-server-cluster']['chef-server']['version']
-  integration_builds node['qa-chef-server-cluster']['chef-server']['integration_builds']
-  repository node['qa-chef-server-cluster']['chef-server']['repo']
+  channel node['qa-chef-server-cluster']['chef-server']['channel']
 end
 
 chef_package 'manage' do
   action :upgrade
   package_url node['qa-chef-server-cluster']['opscode-manage']['url']
-  install_method node['qa-chef-server-cluster']['opscode-manage']['install_method']
   version node['qa-chef-server-cluster']['opscode-manage']['version']
-  integration_builds node['qa-chef-server-cluster']['opscode-manage']['integration_builds']
-  repository node['qa-chef-server-cluster']['opscode-manage']['repo']
+  channel node['qa-chef-server-cluster']['opscode-manage']['channel']
   reconfigure true
   not_if { current_server.product_name == 'open_source_chef' }
 end

--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -22,19 +22,15 @@ include_recipe 'qa-chef-server-cluster::node-setup'
 
 chef_package current_server.package_name do
   package_url node['qa-chef-server-cluster']['chef-server']['url']
-  install_method node['qa-chef-server-cluster']['chef-server']['install_method']
   version node['qa-chef-server-cluster']['chef-server']['version']
-  integration_builds node['qa-chef-server-cluster']['chef-server']['integration_builds']
-  repository node['qa-chef-server-cluster']['chef-server']['repo']
+  channel node['qa-chef-server-cluster']['chef-server']['channel']
   reconfigure true
 end
 
 chef_package 'manage' do
   package_url node['qa-chef-server-cluster']['opscode-manage']['url']
-  install_method node['qa-chef-server-cluster']['opscode-manage']['install_method']
   version node['qa-chef-server-cluster']['opscode-manage']['version']
-  integration_builds node['qa-chef-server-cluster']['opscode-manage']['integration_builds']
-  repository node['qa-chef-server-cluster']['opscode-manage']['repo']
+  channel node['qa-chef-server-cluster']['opscode-manage']['channel']
   reconfigure true
   not_if { current_server.product_name == 'open_source_chef' }
 end

--- a/spec/unit/recipes/chef_package_resource_install_spec.rb
+++ b/spec/unit/recipes/chef_package_resource_install_spec.rb
@@ -12,62 +12,6 @@ describe 'chef_package_resource::install' do
       end
     end
 
-    context 'using artifactory' do
-      let(:chef_run) do
-        ChefSpec::SoloRunner.new(step_into: ['chef_package']).converge(described_recipe)
-      end
-
-      it 'sets up the resource' do
-        expect(chef_run).to install_chef_package('chef-server-artifactory').with(
-          product_name: 'chef-server',
-          install_method: 'artifactory',
-          version: '12.1.1',
-          integration_builds: false,
-          repository: 'omnibus-stable-local',
-          reconfigure: true
-        )
-      end
-
-      it 'calls omnibus_artifactory_artifact' do
-        expect(chef_run).to create_omnibus_artifactory_artifact('chef-server').with(
-          version: '12.1.1',
-          integration_builds: false,
-          repo: 'omnibus-stable-local'
-        )
-      end
-
-      it 'installs package' do
-        expect(chef_run).to install_chef_ingredient('chef-server')
-      end
-
-      it 'reconfigures' do
-        skip
-        expect(chef_run).to reconfigure_chef_ingredient('chef-server')
-      end
-    end
-
-    context 'using packagecloud' do
-      let(:chef_run) do
-        ChefSpec::SoloRunner.new(step_into: ['chef_package']).converge(described_recipe)
-      end
-
-      it 'sets up the resource' do
-        expect(chef_run).to install_chef_package('chef-server-packagecloud').with(
-          product_name: 'chef-server',
-          install_method: 'packagecloud',
-          version: '12.1.1'
-        )
-      end
-
-      it 'calls packagecloud_repo' do
-        expect(chef_run).to create_packagecloud_repo('chef/stable')
-      end
-
-      it 'installs package' do
-        expect(chef_run).to install_chef_ingredient('chef-server')
-      end
-    end
-
     context 'using url' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new(
@@ -78,7 +22,6 @@ describe 'chef_package_resource::install' do
       it 'sets up the resource' do
         expect(chef_run).to install_chef_package('chef-server-url').with(
           product_name: 'chef-server',
-          install_method: 'artifactory', # bypassed
           package_url: 'https://mydomain.com/package.ext'
         )
       end

--- a/spec/unit/recipes/standalone_recipe_chef_server_spec.rb
+++ b/spec/unit/recipes/standalone_recipe_chef_server_spec.rb
@@ -26,75 +26,6 @@ describe 'qa-chef-server-cluster::standalone' do
       end
     end
 
-    context 'when install_method is artifactory' do
-      let(:chef_run) do
-        ChefSpec::SoloRunner.new(step_into: ['chef_package']) do |node|
-          node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'chef_server'
-          node.set['qa-chef-server-cluster']['chef-server']['install_method'] = 'artifactory'
-          node.set['qa-chef-server-cluster']['chef-server']['version'] = :latest
-        end.converge(described_recipe)
-      end
-
-      it 'sets up resource' do
-        expect(chef_run).to install_chef_package('chef-server').with(
-          package_url: nil,
-          install_method: 'artifactory',
-          version: :latest,
-          integration_builds: false,
-          repository: 'omnibus-stable-local',
-          reconfigure: true
-        )
-      end
-
-      it 'uses artifactory' do
-        expect(chef_run).to create_omnibus_artifactory_artifact('chef-server')
-      end
-    end
-
-    context 'when install_method is artifactory private-chef' do
-      let(:chef_run) do
-        ChefSpec::SoloRunner.new(step_into: ['chef_package']) do |node|
-          node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'enterprise_chef'
-          node.set['qa-chef-server-cluster']['chef-server']['install_method'] = 'artifactory'
-          node.set['qa-chef-server-cluster']['chef-server']['version'] = :latest
-        end.converge(described_recipe)
-      end
-
-      it 'sets up resource' do
-        expect(chef_run).to install_chef_package('private-chef').with(
-          package_url: nil,
-          install_method: 'artifactory',
-          version: :latest,
-          integration_builds: false,
-          repository: 'omnibus-stable-local',
-          reconfigure: true
-        )
-      end
-
-      it 'uses artifactory' do
-        expect(chef_run).to create_omnibus_artifactory_artifact('private-chef')
-      end
-    end
-
-    context 'when install_method is packagecloud' do
-      let(:chef_run) do
-        ChefSpec::SoloRunner.new(step_into: ['chef_package']) do |node|
-          node.set['qa-chef-server-cluster']['chef-server']['flavor'] = 'chef_server'
-          node.set['qa-chef-server-cluster']['chef-server']['install_method'] = 'packagecloud'
-          node.set['qa-chef-server-cluster']['chef-server']['version'] = :latest
-        end.converge(described_recipe)
-      end
-
-      it 'sets up packagecloud' do
-        expect(chef_run).to create_packagecloud_repo('chef/stable')
-      end
-
-      it 'uses chef_ingredient' do
-        skip
-        expect(chef_run).to install_chef_ingredient('chef-server')
-      end
-    end
-
     context 'when url is set' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new(step_into: ['chef_package']) do |node|
@@ -105,13 +36,6 @@ describe 'qa-chef-server-cluster::standalone' do
 
       it 'uses url' do
         expect(chef_run).to create_remote_file('/var/chef/cache/package.ext')
-      end
-
-      it 'uses chef_ingredient' do
-        skip
-        expect(chef_run).to install_chef_ingredient('chef-server').with(
-          package_source: "#{::File.join(Chef::Config.file_cache_path, ::File.basename('/var/chef/cache/package.ext'))}"
-        )
       end
     end
 

--- a/test/fixtures/cookbooks/chef_package_resource/recipes/install.rb
+++ b/test/fixtures/cookbooks/chef_package_resource/recipes/install.rb
@@ -1,22 +1,18 @@
 chef_package 'chef-server-artifactory' do
   product_name 'chef-server'
   version '12.1.1'
-  integration_builds false
-  repository 'omnibus-stable-local'
-  install_method 'artifactory'
+  channel 'stable'
   reconfigure true
 end
 
 chef_package 'chef-server-packagecloud' do
   product_name 'chef-server'
   version '12.1.1'
-  install_method 'packagecloud'
 end
 
 chef_package 'chef-server-url' do
   product_name 'chef-server'
   version :latest
-  install_method 'artifactory'
   package_url 'https://mydomain.com/package.ext'
 end
 


### PR DESCRIPTION
This PR represents two goals for qa-chef-server-cluster and the chef-server-acceptance delivery pipeline.
1) Don't bundle, use chefdk
2) Replace all direct backend implementations (artifactory, packagecloud, chef-server-ctl install) with the latest chef-ingredient

This first commit represents the smallest set of changes to both cookbooks to support standalone new installs and upgrades for chef-server.  Yet to be fully tested, but the general idea is all here.  Similar changes will have to be made to all topology recipes.